### PR TITLE
fix: Fix customVolumeMounts for Scan Jobs

### DIFF
--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -166,11 +166,12 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 		templateSpec.Volumes = append(templateSpec.Volumes, s.customVolumes...)
 	}
 	if len(s.customVolumesMount) > 0 {
-		for _, container := range templateSpec.Containers {
-			container.VolumeMounts = append(container.VolumeMounts, s.customVolumesMount...)
+		// Update each container by reference to ensure the changes persist
+		for i := range templateSpec.Containers {
+			templateSpec.Containers[i].VolumeMounts = append(templateSpec.Containers[i].VolumeMounts, s.customVolumesMount...)
 		}
-		for _, initContainer := range templateSpec.InitContainers {
-			initContainer.VolumeMounts = append(initContainer.VolumeMounts, s.customVolumesMount...)
+		for i := range templateSpec.InitContainers {
+			templateSpec.InitContainers[i].VolumeMounts = append(templateSpec.InitContainers[i].VolumeMounts, s.customVolumesMount...)
 		}
 	}
 	templateSpec.PriorityClassName = s.podPriorityClassName


### PR DESCRIPTION
## Description

This PR fixes the customVolumeMounts for Scan Jobs. The existing logic updates individual elements within a slice of structs without using a reference to the original element, which modifies a copy and not the original. This PR modifies the slices using indices to ensure the original elements are updated and that the mount changes persist.


Before:
    Mounts:
      /tmp from tmp (rw)
      /tmp/scan from scanresult (rw)
Conditions:
  Type              Status
  Initialized       False
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  tmp:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  scanresult:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  **var-lib-etcd:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/etcd**

After:
    Mounts:
      /tmp from tmp (rw)
      /tmp/scan from scanresult (rw)
      **/var/lib/etcd from var-lib-etcd (ro)**
Conditions:
  Type              Status
  Initialized       False
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  tmp:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  scanresult:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  **var-lib-etcd:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/etcd**