### PR TITLE
fix: prevent volume + volumemount conflicts and error out to prevent loop

### DIFF
--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -163,17 +163,38 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 	}
 
 	if len(s.customVolumes) > 0 {
-		templateSpec.Volumes = append(templateSpec.Volumes, s.customVolumes...)
+		for _, customVolume := range s.customVolumes {
+			if !volumeExists(templateSpec.Volumes, customVolume.Name) {
+				templateSpec.Volumes = append(templateSpec.Volumes, customVolume)
+			} else {
+				fmt.Printf("Volume with name %s already exists. Skipping addition.\n", customVolume.Name)
+			}
+		}
 	}
 	if len(s.customVolumesMount) > 0 {
 		// Update each container by reference to ensure the changes persist
 		for i := range templateSpec.Containers {
-			templateSpec.Containers[i].VolumeMounts = append(templateSpec.Containers[i].VolumeMounts, s.customVolumesMount...)
+			existingVolumeMounts := templateSpec.Containers[i].VolumeMounts
+			for _, customVolumeMount := range s.customVolumesMount {
+				if !volumeMountExists(existingVolumeMounts, customVolumeMount.MountPath) {
+					templateSpec.Containers[i].VolumeMounts = append(templateSpec.Containers[i].VolumeMounts, customVolumeMount)
+				} else {
+					fmt.Printf("VolumeMount with mountPath %s already exists in container %s. Skipping addition.\n", customVolumeMount.MountPath, templateSpec.Containers[i].Name)
+				}
+			}
 		}
 		for i := range templateSpec.InitContainers {
-			templateSpec.InitContainers[i].VolumeMounts = append(templateSpec.InitContainers[i].VolumeMounts, s.customVolumesMount...)
+			existingVolumeMounts := templateSpec.InitContainers[i].VolumeMounts
+			for _, customVolumeMount := range s.customVolumesMount {
+				if !volumeMountExists(existingVolumeMounts, customVolumeMount.MountPath) {
+					templateSpec.InitContainers[i].VolumeMounts = append(templateSpec.InitContainers[i].VolumeMounts, customVolumeMount)
+				} else {
+					fmt.Printf("VolumeMount with mountPath %s already exists in init container %s. Skipping addition.\n", customVolumeMount.MountPath, templateSpec.InitContainers[i].Name)
+				}
+			}
 		}
 	}
+
 	templateSpec.PriorityClassName = s.podPriorityClassName
 
 	templateSpec.NodeSelector = s.nodeSelector
@@ -464,4 +485,22 @@ func (b *ReportBuilder) clusterVulnerabilityReport() (*v1alpha1.ClusterVulnerabi
 	// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
 	report.OwnerReferences[0].BlockOwnerDeletion = ptr.To[bool](false)
 	return &report, nil
+}
+
+func volumeExists(volumes []corev1.Volume, name string) bool {
+	for _, v := range volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func volumeMountExists(volumeMounts []corev1.VolumeMount, mountPath string) bool {
+	for _, vm := range volumeMounts {
+		if vm.MountPath == mountPath {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -209,7 +209,7 @@ func (r *WorkloadController) reconcileWorkload(workloadKind kube.Kind) reconcile
 		r.SubmitScanJobChan <- ScanJobRequest{Workload: workloadObj, Context: ctx, ClusterSbomReport: reportsData}
 		// collect scan job processing results
 		scanJobResult := <-r.ResultScanJobChan
-		return scanJobResult.Result, scanJobResult.Error
+		return scanJobResult.Result, nil
 	}
 }
 
@@ -218,7 +218,9 @@ func (r *WorkloadController) ProcessScanJob() {
 		log := r.Logger.WithValues("pre scan job processing for workload:", workloadRequest.Workload.GetName())
 		limitExceeded, scanJobsCount, err := r.LimitChecker.Check(workloadRequest.Context)
 		if err != nil {
-			r.ResultScanJobChan <- ScanJobResult{Result: ctrl.Result{}, Error: err}
+			// Log the error and requeue after delay
+			log.Error(err, "Error checking scan job limit, requeueing")
+			r.ResultScanJobChan <- ScanJobResult{Result: ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, Error: nil}
 			continue
 		}
 		log.V(1).Info("Checking scan jobs limit", "count", scanJobsCount, "limit", r.ConcurrentScanJobsLimit)
@@ -228,8 +230,17 @@ func (r *WorkloadController) ProcessScanJob() {
 			r.ResultScanJobChan <- ScanJobResult{Result: ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, Error: nil}
 			continue
 		}
+
 		err = r.SubmitScanJob(workloadRequest.Context, workloadRequest.Workload, workloadRequest.ClusterSbomReport)
-		r.ResultScanJobChan <- ScanJobResult{Result: ctrl.Result{}, Error: err}
+		if err != nil {
+			// Log the error and requeue after delay
+			log.Error(err, "Error submitting scan job, requeueing")
+			r.ResultScanJobChan <- ScanJobResult{Result: ctrl.Result{RequeueAfter: r.Config.ScanJobRetryAfter}, Error: nil}
+			continue
+		}
+
+		// If everything is successful, proceed without requeue
+		r.ResultScanJobChan <- ScanJobResult{Result: ctrl.Result{}, Error: nil}
 	}
 }
 


### PR DESCRIPTION
## Description

Small changes to check for existing volume and volume mount before creating the custom values and handle a situation in which an infinite loop is possible with scan job queuing.

**The build will fail due to the ENV test that needs to be updated.