### PR TITLE
feat: add scanned container image name to error log

### DIFF
--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -352,18 +353,49 @@ func (r *ScanJobController) completedContainers(ctx context.Context, scanJob *ba
 		}
 		return nil, err
 	}
+
+	// Retrieve the annotation to get the container image getting scanned
+	containerImagesAnnotation, ok := scanJob.Annotations["trivy-operator.container-images"]
+	if !ok {
+		log.Error(nil, "Missing trivy-operator.container-images annotation")
+		return nil, fmt.Errorf("missing trivy-operator.container-images annotation")
+	}
+
+	// Parse the JSON string into a map
+	containerImages := make(map[string]string)
+	err = json.Unmarshal([]byte(containerImagesAnnotation), &containerImages)
+	if err != nil {
+		log.Error(err, "Failed to parse trivy-operator.container-images annotation")
+		return nil, fmt.Errorf("failed to parse trivy-operator.container-images annotation: %w", err)
+	}
+
 	completedContainers := make([]string, 0)
-	for container, status := range statuses {
+	for containerName, status := range statuses {
 		if status.ExitCode == 0 {
-			completedContainers = append(completedContainers, container)
+			completedContainers = append(completedContainers, containerName)
 			continue
 		}
+
+		// Get the container image for logging
+		image, ok := containerImages[containerName]
+		if !ok {
+			image = "unknown"
+		}
+
 		if strings.Contains(status.Message, "no child with platform linux") {
-			// Override the reason to be more descriptive for unsupported images (e.g., Windows) instead of the default "Error"
+			// Override the reason to be more descriptive for unsupported images
 			status.Reason = "UnsupportedPlatform"
-			log.Info("Scan job container", "container", container, "status.reason", status.Reason, "status.message", "Container image is using an unsupported platform.")
+			log.Info("Scan job container",
+				"container", containerName,
+				"image", image,
+				"status.reason", status.Reason,
+				"status.message", "Container image is using an unsupported platform.")
 		} else {
-			log.Error(nil, "Scan job container", "container", container, "status.reason", status.Reason, "status.message", status.Message)
+			log.Error(nil, "Scan job container",
+				"container", containerName,
+				"image", image,
+				"status.reason", status.Reason,
+				"status.message", status.Message)
 		}
 	}
 	return completedContainers, nil


### PR DESCRIPTION
## Description

Include the scanned container image name in the error log to provide more context for what image failed to be scanned.
