### PR TITLE
feat: add container log name to logs

### DIFF
--- a/pkg/vulnerabilityreport/controller/scanjob.go
+++ b/pkg/vulnerabilityreport/controller/scanjob.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -54,6 +55,7 @@ func (r *ScanJobController) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	predicates = append(predicates, ManagedByTrivyOperator, IsVulnerabilityReportScan, JobHasAnyCondition)
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("scan-job-controller").
 		For(&batchv1.Job{}, builder.WithPredicates(predicates...)).
 		Complete(r.reconcileJobs())
 }
@@ -343,16 +345,49 @@ func (r *ScanJobController) completedContainers(ctx context.Context, scanJob *ba
 		}
 		return nil, err
 	}
+
+	// Retrieve the annotation to get the container image getting scanned
+	containerImagesAnnotation, ok := scanJob.Annotations["trivy-operator.container-images"]
+	if !ok {
+		log.Error(nil, "Missing trivy-operator.container-images annotation")
+		return nil, fmt.Errorf("missing trivy-operator.container-images annotation")
+	}
+
+	// Parse the JSON string into a map
+	containerImages := make(map[string]string)
+	err = json.Unmarshal([]byte(containerImagesAnnotation), &containerImages)
+	if err != nil {
+		log.Error(err, "Failed to parse trivy-operator.container-images annotation")
+		return nil, fmt.Errorf("failed to parse trivy-operator.container-images annotation: %w", err)
+	}
+
 	completedContainers := make([]string, 0)
-	for container, status := range statuses {
+	for containerName, status := range statuses {
 		if status.ExitCode == 0 {
-			completedContainers = append(completedContainers, container)
+			completedContainers = append(completedContainers, containerName)
 			continue
 		}
+
+		// Get the container image for logging
+		image, ok := containerImages[containerName]
+		if !ok {
+			image = "unknown"
+		}
+
 		if strings.Contains(status.Message, "no child with platform linux") {
-			log.Info("Scan job container", "container", container, "status.reason", status.Reason, "status.message", "Scanning Windows images is not supported.")
+			// Override the reason to be more descriptive for unsupported images
+			status.Reason = "UnsupportedPlatform"
+			log.Info("Scan job container",
+				"container", containerName,
+				"image", image,
+				"status.reason", status.Reason,
+				"status.message", "Container image is using an unsupported platform.")
 		} else {
-			log.Error(nil, "Scan job container", "container", container, "status.reason", status.Reason, "status.message", status.Message)
+			log.Error(nil, "Scan job container",
+				"container", containerName,
+				"image", image,
+				"status.reason", status.Reason,
+				"status.message", status.Message)
 		}
 	}
 	return completedContainers, nil


### PR DESCRIPTION
## Description

Include the scanned container image name in the error log to provide more context for what image failed to be scanned.

## Related issues


Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
