### PR TITLE
truncate sbom vol name

### DIFF
--- a/pkg/plugins/trivy/jobspec.go
+++ b/pkg/plugins/trivy/jobspec.go
@@ -241,7 +241,13 @@ func CreateSbomDataAsSecret(bom v1alpha1.BOM, secretName string) (corev1.Secret,
 
 // CreateVolumeSbomFiles creates a volume and volume mount for the sbom data
 func CreateVolumeSbomFiles(volumeMounts *[]corev1.VolumeMount, volumes *[]corev1.Volume, secretName *string, fileName, mountPath, cname string) {
-	vname := fmt.Sprintf("sbomvol-%s", cname)
+	vnamePrefix := "sbomvol-"
+	// Truncate cname to ensure that vname fits within 63 characters including the prefix
+	maxCnameLength := 62 - len(vnamePrefix)
+	if len(cname) > maxCnameLength {
+		cname = cname[:maxCnameLength]
+	}
+	vname := fmt.Sprintf("%s%s", vnamePrefix, cname)
 	sbomMount := corev1.VolumeMount{
 		Name:      vname,
 		MountPath: mountPath,

--- a/pkg/plugins/trivy/jobspec_test.go
+++ b/pkg/plugins/trivy/jobspec_test.go
@@ -5,13 +5,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/aquasecurity/trivy-operator/pkg/plugins/trivy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
-	"github.com/aquasecurity/trivy-operator/pkg/plugins/trivy"
 )
 
 func TestCreateSbomDataSecret(t *testing.T) {
@@ -41,7 +40,7 @@ func TestCreateSbomDataSecret(t *testing.T) {
 			sbomFile, err := os.ReadFile(tc.sbomDataFilePath)
 			require.NoError(t, err)
 			var bom v1alpha1.BOM
-			err = json.Unmarshal(sbomFile, &bom)
+			err = json.Unmarshal([]byte(sbomFile), &bom)
 			require.NoError(t, err)
 			got, err := trivy.CreateSbomDataAsSecret(bom, tc.secretName)
 			if err == nil {
@@ -53,36 +52,54 @@ func TestCreateSbomDataSecret(t *testing.T) {
 
 func TestCreateVolumes(t *testing.T) {
 	testCases := []struct {
-		name      string
-		vm        []corev1.VolumeMount
-		v         []corev1.Volume
-		cName     string
-		sn        string
-		fn        string
-		mountPath string
+		name         string
+		vm           []corev1.VolumeMount
+		v            []corev1.Volume
+		cName        string
+		sn           string
+		fn           string
+		mountPath    string
+		expectedName string
 	}{
 		{
-			name:      "cretae volumes",
-			vm:        []corev1.VolumeMount{},
-			v:         []corev1.Volume{},
-			sn:        "test",
-			cName:     "cname",
-			mountPath: "/sbom-cname",
-			fn:        "name",
+			name:         "create volumes with normal cname",
+			vm:           []corev1.VolumeMount{},
+			v:            []corev1.Volume{},
+			sn:           "test",
+			cName:        "cname",
+			mountPath:    "/sbom-cname",
+			fn:           "name",
+			expectedName: "sbomvol-cname",
+		},
+		{
+			name:         "create volumes with long cname",
+			vm:           []corev1.VolumeMount{},
+			v:            []corev1.Volume{},
+			sn:           "test",
+			cName:        "averylongcontainername1234567890averylongcontainername1234567890",
+			mountPath:    "/sbom-longname",
+			fn:           "name",
+			expectedName: "sbomvol-averylongcontainername1234567890averylongcontainername",
 		},
 	}
-	tc := testCases[0]
-	t.Run(tc.name, func(t *testing.T) {
-		trivy.CreateVolumeSbomFiles(&tc.vm, &tc.v, &tc.sn, tc.fn, tc.mountPath, tc.cName)
 
-		assert.Len(t, tc.vm, 1)
-		assert.Len(t, tc.v, 1)
-		assert.Equal(t, "sbomvol-cname", tc.vm[0].Name)
-		assert.Equal(t, "/sbom-cname", tc.vm[0].MountPath)
-		assert.Equal(t, "sbomvol-cname", tc.v[0].Name)
-		assert.Equal(t, tc.sn, tc.v[0].Secret.SecretName)
-		assert.Equal(t, "bom", tc.v[0].Secret.Items[0].Key)
-		assert.Equal(t, tc.fn, tc.v[0].Secret.Items[0].Path)
-	})
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			trivy.CreateVolumeSbomFiles(&tc.vm, &tc.v, &tc.sn, tc.fn, tc.mountPath, tc.cName)
 
+			assert.Equal(t, len(tc.vm), 1)
+			assert.Equal(t, len(tc.v), 1)
+
+			assert.Equal(t, tc.vm[0].Name, tc.expectedName)
+			assert.Equal(t, tc.vm[0].MountPath, tc.mountPath)
+			assert.Equal(t, tc.v[0].Name, tc.expectedName)
+			assert.Equal(t, tc.v[0].Secret.SecretName, tc.sn)
+			assert.Equal(t, tc.v[0].Secret.Items[0].Key, "bom")
+			assert.Equal(t, tc.v[0].Secret.Items[0].Path, tc.fn)
+
+			assert.LessOrEqual(t, len(tc.vm[0].Name), 63)
+			assert.LessOrEqual(t, len(tc.v[0].Name), 63)
+		})
+	}
 }


### PR DESCRIPTION
## Description

Truncate cname to a max of 63 characters.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
