### PR TITLE
feat: Support custom environment variables in scanjob containers.

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -125,7 +125,7 @@ Keeps security report resources updated
 | targetNamespaces | string | `""` | targetNamespace defines where you want trivy-operator to operate. By default, it's a blank string to select all namespaces, but you can specify another namespace, or a comma separated list of namespaces. |
 | targetWorkloads | string | `"pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"` | targetWorkloads is a comma seperated list of Kubernetes workload resources to be included in the vulnerability and config-audit scans if left blank, all workload resources will be scanned |
 | tolerations | list | `[]` | tolerations set the operator tolerations |
-| trivy.additionalVulnerabilityReportFields | string | `""` | additionalVulnerabilityReportFields is a comma separated list of additional fields which can be added to the VulnerabilityReport. Supported parameters: Description, Links, CVSS, Target, Class, PackagePath, PackageType, SeveritySource, and DataSource |
+| trivy.additionalVulnerabilityReportFields | string | `""` | additionalVulnerabilityReportFields is a comma separated list of additional fields which can be added to the VulnerabilityReport. Supported parameters: Description, Links, CVSS, Target, Class, PackagePath, PackageType, PackageType, SeveritySource, and DataSource |
 | trivy.clientServerSkipUpdate | bool | `false` | clientServerSkipUpdate is the flag to enable skip databases update for Trivy client. Only applicable in ClientServer mode. |
 | trivy.command | string | `"image"` | command. One of `image`, `filesystem` or `rootfs` scanning, depending on the target type required for the scan. For 'filesystem' and `rootfs` scanning, ensure that the `trivyOperator.scanJobPodTemplateContainerSecurityContext` is configured to run as the root user (runAsUser = 0). |
 | trivy.createConfig | bool | `true` | createConfig indicates whether to create config objects |
@@ -135,6 +135,7 @@ Keeps security report resources updated
 | trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
 | trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
+| trivy.env | list | `[]` |  |
 | trivy.externalRegoPoliciesEnabled | bool | `false` | The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies  |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |
 | trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |

--- a/deploy/helm/templates/configmaps/operator.yaml
+++ b/deploy/helm/templates/configmaps/operator.yaml
@@ -86,6 +86,9 @@ data:
   {{- if .Values.operator.builtInTrivyServer }}
   trivy.serverURL: {{ printf "http://%s.%s:%s" .Values.trivy.serverServiceName (include "trivy-operator.namespace" .) "4954"  | quote }}
   {{- end }}
+  {{- if .Values.trivy.env }}
+  trivy.env: "{{ .Values.trivy.env | toJson }}"
+  {{- end }}
   node.collector.imageRef: "{{ include "global.imageRegistry" . | default .Values.nodeCollector.registry }}/{{ .Values.nodeCollector.repository }}:{{ .Values.nodeCollector.tag }}"
   policies.bundle.oci.ref: "{{ .Values.policiesBundle.registry }}/{{ .Values.policiesBundle.repository }}:{{ .Values.policiesBundle.tag }}"
   policies.bundle.insecure: {{ .Values.policiesBundle.insecure | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -603,6 +603,13 @@ trivy:
 
   # -- valuesFromSecret name of a Secret to apply TRIVY_* environment variables. Will override Helm AND ConfigMap values.
   valuesFromSecret: ""
+  
+  # Custom environment variables to be set in the scanJob pods.
+  env:
+    - name: CUSTOM_ENV
+      value: "customValue"
+    - name: ANOTHER_ENV
+      value: "anotherValue"
 
 compliance:
   # -- failEntriesLimit the flag to limit the number of fail entries per control check in the cluster compliance detail report

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -605,11 +605,11 @@ trivy:
   valuesFromSecret: ""
   
   # Custom environment variables to be set in the scanJob pods.
-  env:
-    - name: CUSTOM_ENV
-      value: "customValue"
-    - name: ANOTHER_ENV
-      value: "anotherValue"
+  env: []
+    # - name: FOO
+    #   value: "bar"
+    # - name: BAZ
+    #   value: "qux"
 
 compliance:
   # -- failEntriesLimit the flag to limit the number of fail entries per control check in the cluster compliance detail report

--- a/pkg/plugins/trivy/config.go
+++ b/pkg/plugins/trivy/config.go
@@ -5,6 +5,7 @@ import (
 
 	"path/filepath"
 
+	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -22,6 +23,7 @@ import (
 const (
 	keyTrivyImageRepository = "trivy.repository"
 	keyTrivyImageTag        = "trivy.tag"
+	KeyTrivyScanJobEnv      = "trivy.env"
 	//nolint:gosec
 	keyTrivyImagePullSecret                     = "trivy.imagePullSecret"
 	keyTrivyImagePullPolicy                     = "trivy.imagePullPolicy"
@@ -554,4 +556,20 @@ func (c Config) setResourceLimit(configKey string, k8sResourceList *corev1.Resou
 
 func (c Config) GetDBRepository() (string, error) {
 	return c.GetRequiredData(keyTrivyDBRepository)
+}
+
+// GetUserDefinedEnv retrieves and unmarshals the trivy.env JSON from the ConfigMap.
+func (c Config) GetUserDefinedEnv() ([]corev1.EnvVar, error) {
+	raw, ok := c.Data[KeyTrivyScanJobEnv]
+	if !ok || raw == "" {
+		// No custom environment variables defined
+		return nil, nil
+	}
+
+	var envVars []corev1.EnvVar
+	err := json.Unmarshal([]byte(raw), &envVars)
+	if err != nil {
+		return nil, err
+	}
+	return envVars, nil
 }

--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -219,7 +219,12 @@ func GetPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, config Confi
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
-
+		// Retrieve custom environment variables
+		userEnv, err := config.GetUserDefinedEnv()
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+		env = append(env, userEnv...)
 		fscommand := []string{SharedVolumeLocationOfTrivy}
 		args := GetFSScanningArgs(ctx, command, Standalone, "")
 		if len(clusterSboms) > 0 { // trivy sbom ...
@@ -450,6 +455,12 @@ func GetPodSpecForClientServerFSMode(ctx trivyoperator.PluginContext, config Con
 			return corev1.PodSpec{}, nil, err
 		}
 
+		// Retrieve custom environment variables
+		userEnv, err := config.GetUserDefinedEnv()
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+		env = append(env, userEnv...)
 		fscommand := []string{SharedVolumeLocationOfTrivy}
 		args := GetFSScanningArgs(ctx, command, ClientServer, encodedTrivyServerURL.String())
 		if len(clusterSboms) > 0 { // trivy sbom ...

--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -284,6 +284,12 @@ func GetPodSpecForStandaloneMode(ctx trivyoperator.PluginContext,
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
+		// Retrieve custom environment variables
+		userEnv, err := config.GetUserDefinedEnv()
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+		env = append(env, userEnv...)
 		resultFileName := getUniqueScanResultFileName(c.Name)
 		cmd, args := getCommandAndArgs(ctx, Standalone, imageRef.String(), "", resultFileName)
 		if len(clusterSboms) > 0 { // trivy sbom ...
@@ -521,6 +527,12 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
 		}
+		// Retrieve custom environment variables
+		userEnv, err := config.GetUserDefinedEnv()
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+		env = append(env, userEnv...)
 		resultFileName := getUniqueScanResultFileName(container.Name)
 		cmd, args := getCommandAndArgs(ctx, ClientServer, imageRef.String(), encodedTrivyServerURL.String(), resultFileName)
 		if len(clusterSboms) > 0 { // trivy sbom ...


### PR DESCRIPTION
## Description
Pass custom environment variables to the scanjob containers.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
