### PR TITLE
Fix: Image filtering not working as expected in ClientServer Mode

### DIFF
--- a/pkg/plugins/trivy/filesystem.go
+++ b/pkg/plugins/trivy/filesystem.go
@@ -162,6 +162,9 @@ func GetPodSpecForStandaloneFSMode(ctx trivyoperator.PluginContext, config Confi
 	}
 
 	for _, c := range getContainers(spec) {
+		if ExcludeImage(ctx.GetTrivyOperatorConfig().ExcludeImages(), c.Image) {
+			continue
+		}
 		env := []corev1.EnvVar{
 			constructEnvVarSourceFromConfigMap("TRIVY_SEVERITY", trivyConfigName, KeyTrivySeverity),
 			ConfigWorkloadAnnotationEnvVars(workload, SkipFilesAnnotation, "TRIVY_SKIP_FILES", trivyConfigName, keyTrivySkipFiles),

--- a/pkg/plugins/trivy/image.go
+++ b/pkg/plugins/trivy/image.go
@@ -429,6 +429,9 @@ func GetPodSpecForClientServerMode(ctx trivyoperator.PluginContext, config Confi
 	}
 
 	for _, container := range containersSpec {
+		if ExcludeImage(ctx.GetTrivyOperatorConfig().ExcludeImages(), container.Image) {
+			continue
+		}
 		env := []corev1.EnvVar{
 			constructEnvVarSourceFromConfigMap("HTTP_PROXY", trivyConfigName, keyTrivyHTTPProxy),
 			constructEnvVarSourceFromConfigMap("HTTPS_PROXY", trivyConfigName, keyTrivyHTTPSProxy),

--- a/pkg/trivyoperator/config.go
+++ b/pkg/trivyoperator/config.go
@@ -79,7 +79,7 @@ const (
 	KeyScanJobContainerSecurityContext     = "scanJob.podTemplateContainerSecurityContext"
 	keyScanJobPodSecurityContext           = "scanJob.podTemplatePodSecurityContext"
 	keyScanJobPodTemplateLabels            = "scanJob.podTemplateLabels"
-	keyScanJobExcludeImags                 = "scanJob.excludeImages"
+	keyScanJobExcludeImages                = "scanJob.excludeImages"
 	KeyScanJobPodPriorityClassName         = "scanJob.podPriorityClassName"
 	keyComplianceFailEntriesLimit          = "compliance.failEntriesLimit"
 	keySkipResourceByLabels                = "skipResourceByLabels"
@@ -208,7 +208,7 @@ func (c ConfigData) GetScanJobTolerations() ([]corev1.Toleration, error) {
 
 func (c ConfigData) ExcludeImages() []string {
 	patterns := make([]string, 0)
-	if excludeImagesPattern, ok := c[keyScanJobExcludeImags]; ok {
+	if excludeImagesPattern, ok := c[keyScanJobExcludeImages]; ok {
 		for _, s := range strings.Split(excludeImagesPattern, ",") {
 			if strings.TrimSpace(s) == "" {
 				continue


### PR DESCRIPTION
## Description

Image exclusion is not respected in image scanning in ClientServer mode and filesystem scanning in Standalone mode due to missing calls to the ExcludeImage function when creating the containers slice.

Additional fix to misspelled key.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
