### PR TITLE
bug: unit test now passing.

### DIFF
--- a/pkg/policy/loader.go
+++ b/pkg/policy/loader.go
@@ -116,7 +116,11 @@ func (pl *policyLoader) getBuiltInPolicies(ctx context.Context) ([]string, error
 	if err = client.DownloadBuiltinChecks(ctx, pl.RegistryOptions); err != nil {
 		return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 	}
-	return client.LoadBuiltinChecks()
+	check := client.LoadBuiltinChecks()
+	if check == "" {
+		return nil, xerrors.Errorf("failed to load built-in checks")
+	}
+	return []string{check}, nil
 }
 
 func LoadPoliciesData(policyPath []string) ([]string, error) {


### PR DESCRIPTION
## Description

Fix build error:

#[error]#7 77.25 pkg/policy/loader.go:119:9: not enough return values
##[error]#7 77.25 	have (string)
##[error]#7 77.25 	want ([]string, error)


## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
