### PR TITLE
fix: remove secrets from failed job

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -136,6 +136,7 @@ Keeps security report resources updated
 | trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
 | trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
+| trivy.env | list | `[]` |  |
 | trivy.existingSecret | bool | `false` | existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...). Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders Overrides trivy.gitHubToken, trivy.serverToken, trivy.serverCustomHeaders values. Note: The secret has to be named "trivy-operator-trivy-config". |
 | trivy.externalRegoPoliciesEnabled | bool | `false` | The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies  |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |

--- a/pkg/vulnerabilityreport/controller/workload.go
+++ b/pkg/vulnerabilityreport/controller/workload.go
@@ -373,7 +373,15 @@ func (r *WorkloadController) SubmitScanJob(ctx context.Context, owner client.Obj
 	err = r.Client.Create(ctx, scanJob)
 	if err != nil {
 		if k8sapierror.IsAlreadyExists(err) {
-			// TODO Delete secrets that were created in the previous step. Alternatively we can delete them on schedule.
+			// Delete secrets that were created in the previous step
+			for _, secret := range secrets {
+				deleteErr := r.Client.Delete(ctx, secret)
+				if deleteErr != nil && !k8sapierror.IsNotFound(deleteErr) {
+					log.Error(deleteErr, "failed to delete secret", "secret", secret.Namespace+"/"+secret.Name)
+				} else {
+					log.V(1).Info("deleted secret after job creation failure", "secret", secret.Namespace+"/"+secret.Name)
+				}
+			}
 			return nil
 		}
 		return fmt.Errorf("creating scan job failed: %s: %w", scanJob.Namespace+"/"+scanJob.Name, err)


### PR DESCRIPTION
## Description

Delete secrets that were created for a scanJob that failure to create.

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
